### PR TITLE
fix(ios): handle ISO8601 fractional seconds in ScheduleCalculator

### DIFF
--- a/skills/openclix-init/templates/ios/Engine/ScheduleCalculator.swift
+++ b/skills/openclix-init/templates/ios/Engine/ScheduleCalculator.swift
@@ -46,7 +46,7 @@ public final class ScheduleCalculator {
 
     public init() {}
 
-    private func parseISO8601(_ value: String) -> Date? {
+    private func parseIsoDate(_ value: String) -> Date? {
         let fractional = ISO8601DateFormatter()
         fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         if let parsed = fractional.date(from: value) {
@@ -59,9 +59,9 @@ public final class ScheduleCalculator {
         var executeAtDate: Date
 
         if let executeAt = input.execute_at,
-           let parsedDate = parseISO8601(executeAt) {
+           let parsedDate = parseIsoDate(executeAt) {
             executeAtDate = parsedDate
-        } else if let parsedDate = parseISO8601(input.now) {
+        } else if let parsedDate = parseIsoDate(input.now) {
             executeAtDate = parsedDate
             if input.execute_at == nil,
                let delaySeconds = input.delay_seconds,
@@ -92,6 +92,8 @@ public final class ScheduleCalculator {
 
 private extension Date {
     func formattedISO8601() -> String {
-        return ISO8601DateFormatter().string(from: self)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: self)
     }
 }


### PR DESCRIPTION
## Summary
- `CampaignProcessor.toIsoString()` formats timestamps with `.withFractionalSeconds` (e.g. `2026-03-03T01:34:55.123Z`), but `ScheduleCalculator.calculate()` used the default `ISO8601DateFormatter()` which silently returns `nil` for fractional-second strings
- This caused `execute_at` to fall through to `Date()`, replacing future execution times with "now" and breaking event campaign delays and recurring schedules
- Added a `parseISO8601` helper that tries `.withFractionalSeconds` first, then falls back to the default formatter — matching the pattern already used in `CampaignProcessor.parseIsoDate`

## Scope
- **Only iOS is affected.** React Native (`new Date()`), Android (`parseIso8601()` with `.SSS` fallback), and Flutter (`DateTime.parse()`) all handle fractional seconds correctly already.

## Test plan
- [ ] Verify Swift typecheck passes (`verify_templates.sh ios`)
- [ ] Confirm `ScheduleCalculator.calculate()` preserves the original `execute_at` when the input contains fractional seconds (e.g. `.123Z` suffix)
- [ ] Confirm non-fractional timestamps (e.g. `2026-03-03T01:34:55Z`) still parse correctly via the fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)