### PR TITLE
feat(templates): add notification permission and foreground display

### DIFF
--- a/docs/getting-started/verification.mdx
+++ b/docs/getting-started/verification.mdx
@@ -10,6 +10,8 @@ Use this checklist after running the workflow.
 - Run your platform build/analyze commands successfully.
 - Confirm OpenClix touchpoints are wired in app initialization/event/lifecycle paths.
 - Confirm local notification / in-app hook paths execute in test scenarios.
+- Confirm notification permission is requested before campaign triggers fire.
+- Confirm foreground notification display is configured (iOS / Expo).
 
 ## Artifact checks
 

--- a/skills/openclix-init/SKILL.md
+++ b/skills/openclix-init/SKILL.md
@@ -91,6 +91,37 @@ Platform expectations:
   - Use platform-native implementations by default
   - Do not introduce in-memory/no-op fallback as the default runtime behavior
 
+## Notification Permission and Foreground Setup
+
+Notification permission must be requested before campaign triggers fire. Each platform template includes a permission utility; the integration agent must wire it at the appropriate location in the host app.
+
+### React Native / Expo — Permission
+
+- **Notifee projects:** Import `requestNotifeePermission` from `infrastructure/NotifeeNotificationSetup`. Call it at app startup (e.g. in `App.tsx` or a startup hook) passing the Notifee adapter. No foreground handler is needed — Notifee handles foreground display natively via `presentationOptions`.
+- **Expo projects:** Import `requestExpoPermission` and `setupExpoForegroundHandler` from `infrastructure/ExpoNotificationSetup`. Call `setupExpoForegroundHandler` once during initialization, then call `requestExpoPermission` at app startup.
+
+### iOS — Permission and Foreground Display
+
+1. **Permission:** Call `await NotificationPermission.request()` at app startup (e.g. in `application(_:didFinishLaunchingWithOptions:)` or a SwiftUI `.task` modifier). This calls `UNUserNotificationCenter.requestAuthorization`.
+2. **Foreground display:** iOS suppresses notification banners when the app is active. The template provides `ForegroundNotificationHandler.handleWillPresent(notification:completionHandler:)` as a static method.
+   - **Critical:** iOS allows only ONE `UNUserNotificationCenterDelegate` per app. Do NOT assign `ForegroundNotificationHandler` as the delegate. Instead, set the app's existing delegate (usually `AppDelegate`) as `UNUserNotificationCenter.current().delegate = self`, and call the static method from the delegate's `willPresent` implementation.
+
+### Android — Permission
+
+1. **Manifest:** Add `<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />` to `AndroidManifest.xml`.
+2. **Runtime request:** On API 33+ (Android 13), call `NotificationPermission.shouldRequestPermission(context)` at startup. If it returns `true`, use the Activity's `requestPermissions()` or `ActivityResultLauncher` to request `NotificationPermission.getPermissionString()`.
+3. Android does NOT need foreground display setup — `NotificationManager.notify()` always displays regardless of app state.
+
+### Flutter — Permission and Foreground Display
+
+The `NotificationPermission` class in `notification/notification_permission.dart` accepts callbacks. Wire the host app's notification plugin:
+
+1. Provide a `requestPermission` callback that calls the plugin's permission request API.
+2. Provide a `checkPermissionStatus` callback that checks current status.
+3. Optionally provide a `setupForegroundHandler` callback to configure foreground display (required for iOS, not needed for Android).
+4. Call `permission.request()` at app startup before campaign triggers fire.
+5. Call `permission.setupForeground()` during initialization if the handler is provided.
+
 ## Directory and Namespace Policy
 
 OpenClix files must stay grouped in a dedicated location:

--- a/skills/openclix-init/templates/android/notification/NotificationPermission.kt
+++ b/skills/openclix-init/templates/android/notification/NotificationPermission.kt
@@ -1,0 +1,75 @@
+package ai.openclix.notification
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+
+/**
+ * Permission status for notifications.
+ */
+enum class NotificationPermissionStatus {
+    /** Permission is granted (or not required on API < 33). */
+    GRANTED,
+    /** Permission was denied by the user. */
+    DENIED,
+    /** Permission is not required on this API level (< 33). */
+    NOT_REQUIRED
+}
+
+/**
+ * Utility for checking notification permission on Android 13+ (API 33).
+ *
+ * On API < 33, notifications do not require runtime permission, so
+ * [checkStatus] returns [NotificationPermissionStatus.NOT_REQUIRED].
+ *
+ * This class does NOT launch the permission request dialog. The host
+ * Activity must use [getPermissionString] with its own
+ * `ActivityResultLauncher<String>` or `requestPermissions()` call.
+ *
+ * Example usage in an Activity:
+ * ```kotlin
+ * if (NotificationPermission.shouldRequestPermission(this)) {
+ *     val permission = NotificationPermission.getPermissionString()!!
+ *     requestPermissions(arrayOf(permission), REQUEST_CODE)
+ * }
+ * ```
+ */
+object NotificationPermission {
+
+    private const val POST_NOTIFICATIONS = "android.permission.POST_NOTIFICATIONS"
+
+    /**
+     * Check the current notification permission status.
+     */
+    fun checkStatus(context: Context): NotificationPermissionStatus {
+        if (Build.VERSION.SDK_INT < 33) {
+            return NotificationPermissionStatus.NOT_REQUIRED
+        }
+        val result = context.checkPermission(
+            POST_NOTIFICATIONS,
+            android.os.Process.myPid(),
+            android.os.Process.myUid()
+        )
+        return if (result == PackageManager.PERMISSION_GRANTED) {
+            NotificationPermissionStatus.GRANTED
+        } else {
+            NotificationPermissionStatus.DENIED
+        }
+    }
+
+    /**
+     * Returns `true` if the app is running on API 33+ and notification
+     * permission has not yet been granted.
+     */
+    fun shouldRequestPermission(context: Context): Boolean {
+        return checkStatus(context) == NotificationPermissionStatus.DENIED
+    }
+
+    /**
+     * Returns the `POST_NOTIFICATIONS` permission string on API 33+,
+     * or `null` on older API levels where no runtime permission is needed.
+     */
+    fun getPermissionString(): String? {
+        return if (Build.VERSION.SDK_INT >= 33) POST_NOTIFICATIONS else null
+    }
+}

--- a/skills/openclix-init/templates/flutter/notification/notification_permission.dart
+++ b/skills/openclix-init/templates/flutter/notification/notification_permission.dart
@@ -1,0 +1,65 @@
+/// Callback to request notification permission from the user.
+/// Returns `true` if permission was granted.
+typedef RequestPermissionCallback = Future<bool> Function();
+
+/// Callback to check current notification permission status
+/// without prompting the user. Returns `true` if granted.
+typedef CheckPermissionStatusCallback = Future<bool> Function();
+
+/// Callback to configure foreground notification display.
+/// Should set up the notification plugin to show banners/alerts
+/// while the app is in the foreground.
+typedef SetupForegroundHandlerCallback = void Function();
+
+/// Wraps platform-specific notification permission and foreground display
+/// callbacks. The host app provides concrete implementations that delegate
+/// to the notification plugin already in use (e.g. flutter_local_notifications,
+/// firebase_messaging).
+///
+/// Example usage:
+/// ```dart
+/// final permission = NotificationPermission(
+///   requestPermission: () async {
+///     // call your notification plugin's permission request
+///     return true;
+///   },
+///   checkPermissionStatus: () async {
+///     // check current permission status
+///     return true;
+///   },
+///   setupForegroundHandler: () {
+///     // configure foreground notification display
+///   },
+/// );
+///
+/// final granted = await permission.request();
+/// if (granted) {
+///   permission.setupForeground();
+/// }
+/// ```
+class NotificationPermission {
+  final RequestPermissionCallback requestPermission;
+  final CheckPermissionStatusCallback checkPermissionStatus;
+  final SetupForegroundHandlerCallback? setupForegroundHandler;
+
+  NotificationPermission({
+    required this.requestPermission,
+    required this.checkPermissionStatus,
+    this.setupForegroundHandler,
+  });
+
+  /// Request notification permission. Returns `true` if granted.
+  Future<bool> request() async {
+    return requestPermission();
+  }
+
+  /// Check current permission status without prompting.
+  Future<bool> checkStatus() async {
+    return checkPermissionStatus();
+  }
+
+  /// Configure foreground notification display if a handler was provided.
+  void setupForeground() {
+    setupForegroundHandler?.call();
+  }
+}

--- a/skills/openclix-init/templates/ios/Notification/ForegroundNotificationHandler.swift
+++ b/skills/openclix-init/templates/ios/Notification/ForegroundNotificationHandler.swift
@@ -1,0 +1,51 @@
+import Foundation
+import UserNotifications
+
+/// Static handler for displaying notifications while the app is in the foreground.
+///
+/// iOS suppresses notification banners when the app is active unless
+/// `UNUserNotificationCenterDelegate.userNotificationCenter(_:willPresent:withCompletionHandler:)`
+/// returns presentation options. This helper provides a static method the host
+/// app's existing delegate can call.
+///
+/// **Important:** iOS allows only ONE `UNUserNotificationCenterDelegate` per app.
+/// Do NOT set this as the delegate directly. Instead, call the static method
+/// from your existing delegate implementation.
+///
+/// Example usage in AppDelegate:
+/// ```swift
+/// class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+///     func application(_ application: UIApplication,
+///                      didFinishLaunchingWithOptions launchOptions: ...) -> Bool {
+///         UNUserNotificationCenter.current().delegate = self
+///         return true
+///     }
+///
+///     func userNotificationCenter(
+///         _ center: UNUserNotificationCenter,
+///         willPresent notification: UNNotification,
+///         withCompletionHandler completionHandler:
+///             @escaping (UNNotificationPresentationOptions) -> Void
+///     ) {
+///         ForegroundNotificationHandler.handleWillPresent(
+///             notification: notification,
+///             completionHandler: completionHandler
+///         )
+///     }
+/// }
+/// ```
+public enum ForegroundNotificationHandler {
+
+    /// Call this from your `UNUserNotificationCenterDelegate.willPresent` implementation
+    /// to display OpenClix notifications as banners while the app is active.
+    public static func handleWillPresent(
+        notification: UNNotification,
+        completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        if #available(iOS 14.0, *) {
+            completionHandler([.banner, .sound, .badge])
+        } else {
+            completionHandler([.alert, .sound, .badge])
+        }
+    }
+}

--- a/skills/openclix-init/templates/ios/Notification/NotificationPermission.swift
+++ b/skills/openclix-init/templates/ios/Notification/NotificationPermission.swift
@@ -1,0 +1,52 @@
+import Foundation
+import UserNotifications
+
+/// Result of a notification permission request or status check.
+public struct NotificationPermissionResult {
+    public let granted: Bool
+    public let status: UNAuthorizationStatus
+}
+
+/// Utility for requesting and checking notification permissions.
+///
+/// Usage:
+/// ```swift
+/// let result = await NotificationPermission.request()
+/// if result.granted {
+///     // safe to schedule notifications
+/// }
+/// ```
+public enum NotificationPermission {
+
+    /// Request notification permission from the user.
+    /// Pass custom options or use the default set (alert, sound, badge).
+    public static func request(
+        options: UNAuthorizationOptions = [.alert, .sound, .badge]
+    ) async -> NotificationPermissionResult {
+        let center = UNUserNotificationCenter.current()
+        do {
+            let granted = try await center.requestAuthorization(options: options)
+            let settings = await center.notificationSettings()
+            return NotificationPermissionResult(
+                granted: granted,
+                status: settings.authorizationStatus
+            )
+        } catch {
+            return NotificationPermissionResult(
+                granted: false,
+                status: .denied
+            )
+        }
+    }
+
+    /// Check the current notification authorization status without prompting.
+    public static func checkStatus() async -> NotificationPermissionResult {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        let granted = settings.authorizationStatus == .authorized
+            || settings.authorizationStatus == .provisional
+        return NotificationPermissionResult(
+            granted: granted,
+            status: settings.authorizationStatus
+        )
+    }
+}

--- a/skills/openclix-init/templates/react-native/infrastructure/ExpoNotificationSetup.ts
+++ b/skills/openclix-init/templates/react-native/infrastructure/ExpoNotificationSetup.ts
@@ -1,0 +1,63 @@
+import type { ExpoNotificationsAdapter } from './ExpoNotificationScheduler';
+
+export interface ExpoPermissionResult {
+  granted: boolean;
+  status: string;
+}
+
+export interface ExpoNotificationSetupAdapter extends ExpoNotificationsAdapter {
+  requestPermissionsAsync(): Promise<{ status: string; granted: boolean }>;
+  getPermissionsAsync(): Promise<{ status: string; granted: boolean }>;
+  setNotificationHandler(handler: {
+    handleNotification: () => Promise<{
+      shouldShowAlert: boolean;
+      shouldPlaySound: boolean;
+      shouldSetBadge: boolean;
+    }>;
+  }): void;
+}
+
+/**
+ * Request notification permission via Expo Notifications.
+ * Call this before scheduling any campaign notifications.
+ */
+export async function requestExpoPermission(
+  adapter: ExpoNotificationSetupAdapter,
+): Promise<ExpoPermissionResult> {
+  const result = await adapter.requestPermissionsAsync();
+  return {
+    granted: result.granted,
+    status: result.status,
+  };
+}
+
+/**
+ * Check current notification permission status via Expo Notifications
+ * without prompting the user.
+ */
+export async function checkExpoPermissionStatus(
+  adapter: ExpoNotificationSetupAdapter,
+): Promise<ExpoPermissionResult> {
+  const result = await adapter.getPermissionsAsync();
+  return {
+    granted: result.granted,
+    status: result.status,
+  };
+}
+
+/**
+ * Configure Expo Notifications to display notifications while
+ * the app is in the foreground.
+ * Call this once during app initialization.
+ */
+export function setupExpoForegroundHandler(
+  adapter: ExpoNotificationSetupAdapter,
+): void {
+  adapter.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldShowAlert: true,
+      shouldPlaySound: true,
+      shouldSetBadge: false,
+    }),
+  });
+}

--- a/skills/openclix-init/templates/react-native/infrastructure/NotifeeNotificationSetup.ts
+++ b/skills/openclix-init/templates/react-native/infrastructure/NotifeeNotificationSetup.ts
@@ -1,0 +1,44 @@
+import type { NotifeeAdapter } from './NotifeeScheduler';
+
+export interface NotifeePermissionResult {
+  granted: boolean;
+  status: string;
+}
+
+export interface NotifeePermissionAdapter extends NotifeeAdapter {
+  requestPermission(): Promise<{ authorizationStatus: number }>;
+  getNotificationSettings(): Promise<{ authorizationStatus: number }>;
+}
+
+/**
+ * Request notification permission via Notifee.
+ * Call this before scheduling any campaign notifications.
+ */
+export async function requestNotifeePermission(
+  adapter: NotifeePermissionAdapter,
+): Promise<NotifeePermissionResult> {
+  const result = await adapter.requestPermission();
+  // Notifee authorizationStatus: 1 = AUTHORIZED, 2 = PROVISIONAL
+  const granted =
+    result.authorizationStatus === 1 || result.authorizationStatus === 2;
+  return {
+    granted,
+    status: String(result.authorizationStatus),
+  };
+}
+
+/**
+ * Check current notification permission status via Notifee
+ * without prompting the user.
+ */
+export async function checkNotifeePermissionStatus(
+  adapter: NotifeePermissionAdapter,
+): Promise<NotifeePermissionResult> {
+  const settings = await adapter.getNotificationSettings();
+  const granted =
+    settings.authorizationStatus === 1 || settings.authorizationStatus === 2;
+  return {
+    granted,
+    status: String(settings.authorizationStatus),
+  };
+}


### PR DESCRIPTION
## Summary

- Add notification permission request/check utilities to all platform templates (React Native, iOS, Android, Flutter)
- Add iOS foreground notification display handler (static method, not a delegate — respects singleton constraint)
- Update SKILL.md with per-platform agent wiring instructions for permission requesting and foreground setup
- Add verification checklist items for permission and foreground display in docs

## Details

Notifications currently silently fail across platforms because permission is never requested:
- **iOS**: No `requestAuthorization` called, no `willPresent` delegate for foreground display
- **Android 13+**: No `POST_NOTIFICATIONS` runtime permission requested
- **React Native/Flutter**: Permission delegated to library but never invoked

New template files:
| Platform | File | Purpose |
|----------|------|---------|
| React Native | `infrastructure/NotifeeNotificationSetup.ts` | Notifee permission via adapter |
| React Native | `infrastructure/ExpoNotificationSetup.ts` | Expo permission + foreground handler |
| iOS | `Notification/NotificationPermission.swift` | `UNUserNotificationCenter.requestAuthorization` |
| iOS | `Notification/ForegroundNotificationHandler.swift` | Static `handleWillPresent` for foreground banners |
| Android | `notification/NotificationPermission.kt` | `POST_NOTIFICATIONS` check for API 33+ |
| Flutter | `notification/notification_permission.dart` | Callback-based permission contract |

## Test plan

- [ ] `./scripts/verify_templates.sh all` passes (0 failures)
- [ ] React Native files are in `infrastructure/` (isolated from core/engine)
- [ ] iOS Swift typecheck passes
- [ ] Android kotlinc compile passes (requires kotlinc + android.jar)
- [ ] Flutter analyze passes (requires flutter SDK)
- [ ] No existing template files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)