### PR TITLE
fix(ios): enforce Sendable on protocols and types crossing actor boundaries

### DIFF
--- a/skills/openclix-init/templates/ios/Engine/TriggerService.swift
+++ b/skills/openclix-init/templates/ios/Engine/TriggerService.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct TriggerServiceDependencies {
+public struct TriggerServiceDependencies: Sendable {
     public let campaignStateRepository: OpenClixCampaignStateRepository
     public let messageScheduler: OpenClixMessageScheduler
     public let clock: OpenClixClock

--- a/skills/openclix-init/templates/ios/Models/OpenClixTypes.swift
+++ b/skills/openclix-init/templates/ios/Models/OpenClixTypes.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - JSON Value
 
-public enum JsonValue: Codable, Equatable {
+public enum JsonValue: Codable, Equatable, Sendable {
     case string(String)
     case number(Double)
     case bool(Bool)
@@ -424,7 +424,7 @@ public struct QueuedMessageContent: Codable, Equatable {
 
 // MARK: - Event
 
-public enum EventSourceType: String, Codable, Equatable {
+public enum EventSourceType: String, Codable, Equatable, Sendable {
     case app
     case system
 }
@@ -437,7 +437,7 @@ public enum SystemEventName: String, Codable, Equatable {
     case openClixMessageFailed = "openclix.message.failed"
 }
 
-public struct Event: Codable, Equatable {
+public struct Event: Codable, Equatable, Sendable {
     public let id: String
     public let name: String
     public let source_type: EventSourceType
@@ -642,7 +642,7 @@ public struct OpenClixConfig {
 
 // MARK: - Dependency Protocols
 
-public protocol OpenClixClock {
+public protocol OpenClixClock: Sendable {
     func now() -> String
 }
 
@@ -651,7 +651,7 @@ public protocol OpenClixLifecycleStateReader {
     func setAppState(_ newState: String)
 }
 
-public protocol OpenClixLogger {
+public protocol OpenClixLogger: Sendable {
     func debug(_ message: String, _ args: Any...)
     func info(_ message: String, _ args: Any...)
     func warn(_ message: String, _ args: Any...)
@@ -659,13 +659,13 @@ public protocol OpenClixLogger {
     func setLogLevel(_ level: OpenClixLogLevel)
 }
 
-public protocol OpenClixMessageScheduler {
+public protocol OpenClixMessageScheduler: Sendable {
     func schedule(_ record: QueuedMessage) async throws
     func cancel(_ id: String) async throws
     func listPending() async throws -> [QueuedMessage]
 }
 
-public protocol OpenClixCampaignStateRepository {
+public protocol OpenClixCampaignStateRepository: Sendable {
     func loadSnapshot(now: String) async throws -> CampaignStateSnapshot
     func saveSnapshot(_ snapshot: CampaignStateSnapshot) async throws
     func clearCampaignState() async throws


### PR DESCRIPTION
## Summary
- Require `Sendable` on `OpenClixClock`, `OpenClixLogger`, `OpenClixMessageScheduler`, and `OpenClixCampaignStateRepository` protocols
- Add `Sendable` to `JsonValue`, `Event`, and `EventSourceType` value types
- Mark `TriggerServiceDependencies` as `Sendable`

## Context
Follow-up to #10. The initial fix added `Sendable` to concrete types (`DefaultClock`, `DefaultLogger`, `LocalNotificationScheduler`) but the crash persisted because the **protocols** those types conform to didn't require `Sendable`. This meant `TriggerServiceDependencies` — which stores protocol existentials (`any OpenClixLogger`, `any OpenClixClock`, etc.) — crossed from the `Coordinator` actor to the `TriggerService` actor as a non-Sendable value. Similarly, `Event` crossed actor boundaries (TriggerService → `recordEvent` closure → `FileCampaignStateRepository`) without `Sendable` conformance.

This commit makes the entire dependency chain Sendable from `Coordinator` → `TriggerServiceDependencies` → `TriggerService` → `recordEvent` closure → `FileCampaignStateRepository`.

## Test plan
- [x] `./scripts/verify_templates.sh ios` passes (0 failures, 0 warnings)
- [ ] Manual verification: initialize SDK and confirm no `EXC_BAD_ACCESS` crash
- [ ] Verify strict concurrency checking produces no warnings for cross-actor transfers

🤖 Generated with [Claude Code](https://claude.com/claude-code)