### PR TITLE
fix(ios): resolve Sendable data race in TriggerService templates

### DIFF
--- a/skills/openclix-init/templates/ios/Core/OpenClix.swift
+++ b/skills/openclix-init/templates/ios/Core/OpenClix.swift
@@ -123,11 +123,8 @@ public final class OpenClix {
                 dependencies: TriggerServiceDependencies(
                     campaignStateRepository: campaignStateRepository,
                     messageScheduler: messageScheduler,
-                    clock: DefaultClock(),
-                    logger: DefaultLogger(level: config.logLevel),
-                    recordEvent: { [coordinator = self] event in
-                        await coordinator.persistEvent(event)
-                    }
+                    clock: clock,
+                    logger: logger
                 )
             )
             self.triggerService = triggerService

--- a/skills/openclix-init/templates/ios/Engine/TriggerService.swift
+++ b/skills/openclix-init/templates/ios/Engine/TriggerService.swift
@@ -5,24 +5,22 @@ public struct TriggerServiceDependencies: Sendable {
     public let messageScheduler: OpenClixMessageScheduler
     public let clock: OpenClixClock
     public let logger: OpenClixLogger
-    public let recordEvent: (@Sendable (Event) async -> Void)?
 
     public init(
         campaignStateRepository: OpenClixCampaignStateRepository,
         messageScheduler: OpenClixMessageScheduler,
         clock: OpenClixClock,
-        logger: OpenClixLogger,
-        recordEvent: (@Sendable (Event) async -> Void)? = nil
+        logger: OpenClixLogger
     ) {
         self.campaignStateRepository = campaignStateRepository
         self.messageScheduler = messageScheduler
         self.clock = clock
         self.logger = logger
-        self.recordEvent = recordEvent
     }
 }
 
 private let maximumTriggerHistorySize = 5_000
+private let maximumEventLogSize = 5_000
 
 public actor TriggerService {
 
@@ -353,8 +351,6 @@ public actor TriggerService {
         properties: [String: JsonValue?],
         createdAt: String
     ) async {
-        guard let recordEvent = dependencies.recordEvent else { return }
-
         var normalizedProperties: [String: JsonValue] = [:]
         for (key, value) in properties {
             if let value {
@@ -362,14 +358,24 @@ public actor TriggerService {
             }
         }
 
-        await recordEvent(
-            Event(
-                id: generateUUID(),
-                name: name.rawValue,
-                source_type: .system,
-                properties: normalizedProperties,
-                created_at: createdAt
-            )
+        let event = Event(
+            id: generateUUID(),
+            name: name.rawValue,
+            source_type: .system,
+            properties: normalizedProperties,
+            created_at: createdAt
         )
+
+        do {
+            try await dependencies.campaignStateRepository.appendEvents(
+                [event],
+                maxEntries: maximumEventLogSize
+            )
+        } catch {
+            dependencies.logger.warn(
+                "[TriggerService] Failed to persist system event \(name.rawValue):",
+                error.localizedDescription
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Enforce `Sendable` conformance on protocols and types crossing actor boundaries
- Eliminate shared mutable objects between `Coordinator` and `TriggerService` actors by removing duplicate instance creation
- Remove `recordEvent` closure from `TriggerServiceDependencies` that captured `Coordinator` actor and caused `EXC_BAD_ACCESS` when called from `TriggerService` actor during concurrent initialization
- `TriggerService.emitSystemEvent` now persists events directly via `campaignStateRepository.appendEvents()` instead of crossing actor boundaries through a closure

## Test plan
- [x] `./scripts/verify_templates.sh ios` — passed
- [x] Example app Xcode build (`ios-mindfulness-app`) — `BUILD SUCCEEDED`
- [ ] Manual verification: trigger `app_boot` campaign during initialization to confirm no `EXC_BAD_ACCESS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)