### PR TITLE
feat(openclix-init): add campaign-level frequency_cap and remove one-time trigger skip

### DIFF
--- a/skills/openclix-init/references/openclix.schema.json
+++ b/skills/openclix-init/references/openclix.schema.json
@@ -65,7 +65,7 @@
       "properties": {
         "frequency_cap": {
           "$ref": "#/$defs/frequency_cap",
-          "description": "Limits the maximum number of messages a user can receive within a rolling time window."
+          "description": "Global frequency cap. Limits the maximum number of messages a user can receive across all campaigns within a rolling time window."
         },
         "do_not_disturb": {
           "$ref": "#/$defs/do_not_disturb",
@@ -169,6 +169,10 @@
         "trigger": {
           "$ref": "#/$defs/campaign_trigger",
           "description": "Defines how and when this campaign is triggered."
+        },
+        "frequency_cap": {
+          "$ref": "#/$defs/frequency_cap",
+          "description": "Campaign-level frequency cap. Limits the maximum number of messages this specific campaign can deliver within a rolling time window. If settings.frequency_cap is also set, both caps are enforced."
         },
         "message": {
           "$ref": "#/$defs/message",
@@ -725,7 +729,7 @@
         "trigger_event_not_matched",
         "trigger_cancel_event_matched"
       ],
-      "description": "Reason why a campaign was not triggered or a queued message was cancelled. 'campaign_not_running' = campaign status is not 'running'. 'campaign_frequency_cap_exceeded' = settings.frequency_cap limit exceeded. 'campaign_do_not_disturb_blocked' = message execute_at falls within settings.do_not_disturb window. 'trigger_event_not_matched' = trigger.event.trigger_event conditions did not match. 'trigger_cancel_event_matched' = trigger.event.cancel_event matched during the delay period."
+      "description": "Reason why a campaign was not triggered or a queued message was cancelled. 'campaign_not_running' = campaign status is not 'running'. 'campaign_frequency_cap_exceeded' = global and/or campaign frequency_cap limit exceeded. 'campaign_do_not_disturb_blocked' = message execute_at falls within settings.do_not_disturb window. 'trigger_event_not_matched' = trigger.event.trigger_event conditions did not match. 'trigger_cancel_event_matched' = trigger.event.cancel_event matched during the delay period."
     },
     "campaign_state_snapshot": {
       "type": "object",

--- a/skills/openclix-init/templates/android/engine/CampaignProcessor.kt
+++ b/skills/openclix-init/templates/android/engine/CampaignProcessor.kt
@@ -156,18 +156,31 @@ class CampaignProcessor {
             return createSkipDecision(campaignId, reason)
         }
 
-        if (campaign.trigger.type != TriggerType.RECURRING && campaignState?.triggered == true) {
-            val reason = "Campaign already triggered"
-            logger.debug("[CampaignProcessor] Campaign $campaignId skipped: $reason")
-            return createSkipDecision(campaignId, reason)
-        }
-
         if (settings?.frequency_cap != null) {
             val frequencyCap = settings.frequency_cap
             val windowStartEpoch = parseIso8601(now) - frequencyCap.window_seconds * 1000L
             val windowStart = toIso8601(windowStartEpoch)
             val countInWindow = snapshot.trigger_history.count { historyRow ->
                 historyRow.triggered_at >= windowStart
+            }
+
+            if (countInWindow >= frequencyCap.max_count) {
+                val reason = "Frequency cap exceeded ($countInWindow/${frequencyCap.max_count} within ${frequencyCap.window_seconds}s)"
+                logger.debug("[CampaignProcessor] Campaign $campaignId skipped: $reason")
+                return createSkipDecision(
+                    campaignId,
+                    reason,
+                    SkipReason.CAMPAIGN_FREQUENCY_CAP_EXCEEDED
+                )
+            }
+        }
+
+        if (campaign.frequency_cap != null) {
+            val frequencyCap = campaign.frequency_cap
+            val windowStartEpoch = parseIso8601(now) - frequencyCap.window_seconds * 1000L
+            val windowStart = toIso8601(windowStartEpoch)
+            val countInWindow = snapshot.trigger_history.count { historyRow ->
+                historyRow.campaign_id == campaignId && historyRow.triggered_at >= windowStart
             }
 
             if (countInWindow >= frequencyCap.max_count) {

--- a/skills/openclix-init/templates/android/models/OpenClixTypes.kt
+++ b/skills/openclix-init/templates/android/models/OpenClixTypes.kt
@@ -95,6 +95,7 @@ data class Campaign(
     val description: String,
     val status: CampaignStatus,
     val trigger: CampaignTrigger,
+    val frequency_cap: FrequencyCap? = null,
     val message: Message
 ) {
     companion object {
@@ -104,6 +105,11 @@ data class Campaign(
             description = json.optString("description", ""),
             status = CampaignStatus.fromValue(json.getString("status")),
             trigger = CampaignTrigger.fromJson(json.getJSONObject("trigger")),
+            frequency_cap = if (json.has("frequency_cap") && !json.isNull("frequency_cap")) {
+                FrequencyCap.fromJson(json.getJSONObject("frequency_cap"))
+            } else {
+                null
+            },
             message = Message.fromJson(json.getJSONObject("message"))
         )
     }

--- a/skills/openclix-init/templates/android/services/ConfigValidator.kt
+++ b/skills/openclix-init/templates/android/services/ConfigValidator.kt
@@ -348,6 +348,27 @@ fun validateConfig(config: Config): ValidationResult {
             )
         }
 
+        campaign.frequency_cap?.let { frequencyCap ->
+            if (frequencyCap.max_count < 1) {
+                errors.add(
+                    ValidationIssue(
+                        path = "$basePath.frequency_cap.max_count",
+                        code = "INVALID_FREQUENCY_CAP",
+                        message = "frequency_cap.max_count must be an integer >= 1"
+                    )
+                )
+            }
+            if (frequencyCap.window_seconds < 1) {
+                errors.add(
+                    ValidationIssue(
+                        path = "$basePath.frequency_cap.window_seconds",
+                        code = "INVALID_FREQUENCY_CAP",
+                        message = "frequency_cap.window_seconds must be an integer >= 1"
+                    )
+                )
+            }
+        }
+
         if (!validTriggerTypes.contains(campaign.trigger.type.value)) {
             errors.add(
                 ValidationIssue(

--- a/skills/openclix-init/templates/flutter/engine/campaign_processor.dart
+++ b/skills/openclix-init/templates/flutter/engine/campaign_processor.dart
@@ -148,11 +148,6 @@ class CampaignProcessor {
       );
     }
 
-    if (campaign.trigger.type != TriggerType.recurring &&
-        campaignState?.triggered == true) {
-      return createSkipDecision(campaignId, 'Campaign already triggered');
-    }
-
     if (settings?.frequencyCap != null) {
       final maxCount = settings!.frequencyCap!.maxCount;
       final windowSeconds = settings.frequencyCap!.windowSeconds;
@@ -163,6 +158,32 @@ class CampaignProcessor {
 
       final recentTriggerCount = snapshot.triggerHistory
           .where((history) => history.triggeredAt.compareTo(windowStart) >= 0)
+          .length;
+
+      if (recentTriggerCount >= maxCount) {
+        return createSkipDecision(
+          campaignId,
+          'Frequency cap exceeded '
+          '($recentTriggerCount/$maxCount within ${windowSeconds}s)',
+          SkipReason.campaignFrequencyCapExceeded,
+        );
+      }
+    }
+
+    if (campaign.frequencyCap != null) {
+      final maxCount = campaign.frequencyCap!.maxCount;
+      final windowSeconds = campaign.frequencyCap!.windowSeconds;
+      final nowDate = parseDateTimeMaybe(now) ?? DateTime.now().toUtc();
+      final windowStart = nowDate
+          .subtract(Duration(seconds: windowSeconds))
+          .toIso8601String();
+
+      final recentTriggerCount = snapshot.triggerHistory
+          .where(
+            (history) =>
+                history.campaignId == campaignId &&
+                history.triggeredAt.compareTo(windowStart) >= 0,
+          )
           .length;
 
       if (recentTriggerCount >= maxCount) {

--- a/skills/openclix-init/templates/flutter/models/openclix_types.dart
+++ b/skills/openclix-init/templates/flutter/models/openclix_types.dart
@@ -191,6 +191,7 @@ class Campaign {
   final String description;
   final CampaignStatus status;
   final CampaignTrigger trigger;
+  final FrequencyCap? frequencyCap;
   final Message message;
 
   Campaign({
@@ -199,6 +200,7 @@ class Campaign {
     required this.description,
     required this.status,
     required this.trigger,
+    this.frequencyCap,
     required this.message,
   });
 
@@ -211,6 +213,13 @@ class Campaign {
       trigger: CampaignTrigger.fromJson(
         Map<String, dynamic>.from(json['trigger'] as Map? ?? const {}),
       ),
+      frequencyCap: json['frequency_cap'] is Map<String, dynamic>
+          ? FrequencyCap.fromJson(json['frequency_cap'] as Map<String, dynamic>)
+          : json['frequency_cap'] is Map
+          ? FrequencyCap.fromJson(
+              Map<String, dynamic>.from(json['frequency_cap'] as Map),
+            )
+          : null,
       message: Message.fromJson(
         Map<String, dynamic>.from(json['message'] as Map? ?? const {}),
       ),
@@ -224,6 +233,7 @@ class Campaign {
       'description': description,
       'status': status.toJson(),
       'trigger': trigger.toJson(),
+      if (frequencyCap != null) 'frequency_cap': frequencyCap!.toJson(),
       'message': message.toJson(),
     };
   }

--- a/skills/openclix-init/templates/flutter/services/config_validator.dart
+++ b/skills/openclix-init/templates/flutter/services/config_validator.dart
@@ -337,6 +337,29 @@ ValidationResult validateConfig(Config config) {
       );
     }
 
+    final campaignFrequencyCap = campaign.frequencyCap;
+    if (campaignFrequencyCap != null) {
+      if (campaignFrequencyCap.maxCount < 1) {
+        errors.add(
+          ValidationIssue(
+            path: '$basePath.frequency_cap.max_count',
+            code: 'INVALID_FREQUENCY_CAP',
+            message: 'frequency_cap.max_count must be an integer >= 1',
+          ),
+        );
+      }
+
+      if (campaignFrequencyCap.windowSeconds < 1) {
+        errors.add(
+          ValidationIssue(
+            path: '$basePath.frequency_cap.window_seconds',
+            code: 'INVALID_FREQUENCY_CAP',
+            message: 'frequency_cap.window_seconds must be an integer >= 1',
+          ),
+        );
+      }
+    }
+
     if (!validTriggerTypes.contains(campaign.trigger.type.value)) {
       errors.add(
         ValidationIssue(

--- a/skills/openclix-init/templates/ios/Engine/CampaignProcessor.swift
+++ b/skills/openclix-init/templates/ios/Engine/CampaignProcessor.swift
@@ -188,17 +188,28 @@ public final class CampaignProcessor {
             )
         }
 
-        if campaign.trigger.type != .recurring,
-           campaignState?.triggered == true {
-            return createSkipDecision(
-                campaignId: campaignId,
-                reason: "Campaign already triggered"
-            )
-        }
-
         if let frequencyCap = settings?.frequency_cap {
             let windowStartDate = nowDate.addingTimeInterval(-Double(frequencyCap.window_seconds))
             let countInWindow = snapshot.trigger_history.reduce(into: 0) { partial, row in
+                guard let triggeredAtDate = parseIsoDate(row.triggered_at) else { return }
+                if triggeredAtDate >= windowStartDate {
+                    partial += 1
+                }
+            }
+
+            if countInWindow >= frequencyCap.max_count {
+                return createSkipDecision(
+                    campaignId: campaignId,
+                    reason: "Frequency cap exceeded (\(countInWindow)/\(frequencyCap.max_count) within \(frequencyCap.window_seconds)s)",
+                    skipReason: .campaign_frequency_cap_exceeded
+                )
+            }
+        }
+
+        if let frequencyCap = campaign.frequency_cap {
+            let windowStartDate = nowDate.addingTimeInterval(-Double(frequencyCap.window_seconds))
+            let countInWindow = snapshot.trigger_history.reduce(into: 0) { partial, row in
+                guard row.campaign_id == campaignId else { return }
                 guard let triggeredAtDate = parseIsoDate(row.triggered_at) else { return }
                 if triggeredAtDate >= windowStartDate {
                     partial += 1

--- a/skills/openclix-init/templates/ios/Models/OpenClixTypes.swift
+++ b/skills/openclix-init/templates/ios/Models/OpenClixTypes.swift
@@ -130,6 +130,7 @@ public struct Campaign: Codable, Equatable {
     public let description: String
     public let status: CampaignStatus
     public let trigger: CampaignTrigger
+    public let frequency_cap: FrequencyCap?
     public let message: Message
 
     public init(
@@ -138,6 +139,7 @@ public struct Campaign: Codable, Equatable {
         description: String,
         status: CampaignStatus,
         trigger: CampaignTrigger,
+        frequency_cap: FrequencyCap? = nil,
         message: Message
     ) {
         self.name = name
@@ -145,6 +147,7 @@ public struct Campaign: Codable, Equatable {
         self.description = description
         self.status = status
         self.trigger = trigger
+        self.frequency_cap = frequency_cap
         self.message = message
     }
 }

--- a/skills/openclix-init/templates/ios/Services/ConfigValidator.swift
+++ b/skills/openclix-init/templates/ios/Services/ConfigValidator.swift
@@ -263,6 +263,28 @@ public func validateConfig(_ config: Config) -> ValidationResult {
             )
         }
 
+        if let frequencyCap = campaign.frequency_cap {
+            if frequencyCap.max_count < 1 {
+                errors.append(
+                    ValidationIssue(
+                        path: "\(basePath).frequency_cap.max_count",
+                        code: "INVALID_FREQUENCY_CAP",
+                        message: "frequency_cap.max_count must be an integer >= 1"
+                    )
+                )
+            }
+
+            if frequencyCap.window_seconds < 1 {
+                errors.append(
+                    ValidationIssue(
+                        path: "\(basePath).frequency_cap.window_seconds",
+                        code: "INVALID_FREQUENCY_CAP",
+                        message: "frequency_cap.window_seconds must be an integer >= 1"
+                    )
+                )
+            }
+        }
+
         switch campaign.trigger.type {
         case .event:
             guard let eventTrigger = campaign.trigger.event else {

--- a/skills/openclix-init/templates/react-native/domain/CampaignProcessor.ts
+++ b/skills/openclix-init/templates/react-native/domain/CampaignProcessor.ts
@@ -126,13 +126,6 @@ export class CampaignProcessor {
       );
     }
 
-    if (
-      campaign.trigger.type !== 'recurring' &&
-      campaignState?.triggered === true
-    ) {
-      return createSkipDecision(campaignId, 'Campaign already triggered');
-    }
-
     // Global frequency cap: count all triggered campaigns in the rolling window.
     if (settings?.frequency_cap) {
       const { max_count, window_seconds } = settings.frequency_cap;
@@ -143,6 +136,24 @@ export class CampaignProcessor {
         (row) => row.triggered_at >= windowStart,
       );
       const countInWindow = recent.length;
+      if (countInWindow >= max_count) {
+        return createSkipDecision(
+          campaignId,
+          `Frequency cap exceeded (${countInWindow}/${max_count} within ${window_seconds}s)`,
+          'campaign_frequency_cap_exceeded',
+        );
+      }
+    }
+
+    // Campaign frequency cap: count triggers for this campaign only in the rolling window.
+    if (campaign.frequency_cap) {
+      const { max_count, window_seconds } = campaign.frequency_cap;
+      const windowStart = new Date(
+        new Date(now).getTime() - window_seconds * 1000,
+      ).toISOString();
+      const countInWindow = (snapshot.trigger_history ?? []).filter(
+        (row) => row.campaign_id === campaignId && row.triggered_at >= windowStart,
+      ).length;
       if (countInWindow >= max_count) {
         return createSkipDecision(
           campaignId,

--- a/skills/openclix-init/templates/react-native/domain/OpenClixTypes.ts
+++ b/skills/openclix-init/templates/react-native/domain/OpenClixTypes.ts
@@ -43,6 +43,7 @@ export interface Campaign {
   description: string;
   status: CampaignStatus;
   trigger: CampaignTrigger;
+  frequency_cap?: FrequencyCap;
   message: Message;
 }
 

--- a/skills/openclix-init/templates/react-native/infrastructure/ConfigValidator.ts
+++ b/skills/openclix-init/templates/react-native/infrastructure/ConfigValidator.ts
@@ -397,7 +397,7 @@ export function validateConfig(config: Config): ValidationResult {
 
       validateNoAdditionalProperties(
         campaign,
-        ['name', 'type', 'description', 'status', 'trigger', 'message'],
+        ['name', 'type', 'description', 'status', 'trigger', 'frequency_cap', 'message'],
         basePath,
         errors,
         'UNEXPECTED_CAMPAIGN_PROPERTY',
@@ -441,6 +441,46 @@ export function validateConfig(config: Config): ValidationResult {
           code: 'INVALID_CAMPAIGN_STATUS',
           message: `Campaign status '${String(campaign.status)}' is not valid (expected 'running' or 'paused')`,
         });
+      }
+
+      if (campaign.frequency_cap !== undefined) {
+        if (!isObjectRecord(campaign.frequency_cap)) {
+          errors.push({
+            path: `${basePath}.frequency_cap`,
+            code: 'INVALID_FREQUENCY_CAP',
+            message: 'frequency_cap must be an object',
+          });
+        } else {
+          validateNoAdditionalProperties(
+            campaign.frequency_cap,
+            ['max_count', 'window_seconds'],
+            `${basePath}.frequency_cap`,
+            errors,
+            'UNEXPECTED_FREQUENCY_CAP_PROPERTY',
+          );
+
+          if (
+            !isInteger(campaign.frequency_cap.max_count) ||
+            campaign.frequency_cap.max_count < 1
+          ) {
+            errors.push({
+              path: `${basePath}.frequency_cap.max_count`,
+              code: 'INVALID_FREQUENCY_CAP',
+              message: 'frequency_cap.max_count must be an integer >= 1',
+            });
+          }
+
+          if (
+            !isInteger(campaign.frequency_cap.window_seconds) ||
+            campaign.frequency_cap.window_seconds < 1
+          ) {
+            errors.push({
+              path: `${basePath}.frequency_cap.window_seconds`,
+              code: 'INVALID_FREQUENCY_CAP',
+              message: 'frequency_cap.window_seconds must be an integer >= 1',
+            });
+          }
+        }
       }
 
       if (!isObjectRecord(campaign.trigger)) {


### PR DESCRIPTION
## Summary
- add optional `campaign.frequency_cap` to OpenClix schema
- add campaign-level `frequency_cap` fields to RN/Android/iOS/Flutter campaign models
- validate campaign-level `frequency_cap` values in all platform validators
- enforce both global (`settings.frequency_cap`) and campaign-level caps in all campaign processors
- remove the non-recurring skip branch that returned `Campaign already triggered`
- update schema skip-reason description for `campaign_frequency_cap_exceeded`

## Validation
- `./scripts/verify_templates.sh react-native` ✅
- `./scripts/verify_templates.sh android` ✅ (compile check skipped: `kotlinc` missing)
- `./scripts/verify_templates.sh ios` ✅
- `./scripts/verify_templates.sh flutter` ✅ (analyze skipped: `flutter` missing)
- `./scripts/verify_templates.sh all` ✅ (same environment warnings)
