### PR TITLE
fix(skills): enforce config path parity and full campaign feature pass

### DIFF
--- a/skills/openclix-design-campaigns/SKILL.md
+++ b/skills/openclix-design-campaigns/SKILL.md
@@ -35,6 +35,7 @@ Gather only missing facts needed for design decisions:
 - current campaign config path (if existing)
 - existing app resource/file management convention for JSON assets
 - startup location where OpenClix is currently initialized (or should be initialized)
+- exact runtime bundled-config load path and filename currently referenced in code (case-sensitive)
 - user-owned HTTP server/deployment target for hosted config (if remote serving is expected)
 - global constraints: quiet hours, frequency cap expectations, locale/timezone assumptions
 
@@ -81,6 +82,16 @@ Content rule:
 - Keep schema-safe limits: title <= 120, body <= 500.
 - Prefer concise UX copy (title <= 45, body <= 140) unless user needs longer copy.
 
+Feature coverage rule (mandatory when adding a new campaign):
+
+- Run a feature pass against `references/schemas/openclix.schema.json` and explicitly evaluate each configurable lever:
+  - global: `settings.frequency_cap`, `settings.do_not_disturb`
+  - campaign: `frequency_cap`
+  - event trigger: `delay_seconds`, `cancel_event`
+  - recurring trigger: `start_at`, `end_at`, `rule.interval`, `weekly_rule.days_of_week`, `time_of_day`
+  - message content: `image_url`, `landing_url`, personalization placeholders
+- Apply every lever that is relevant to the campaign goal; if a lever is not used, state why in handoff assumptions.
+
 ## 4) Generate Or Update OpenClix Config
 
 Before writing config:
@@ -107,6 +118,7 @@ Guarantee these invariants:
 - Campaign `type` is `campaign`.
 - Campaign `status` is `running` or `paused`.
 - Trigger-specific required fields are present.
+- Optional but available fields are intentionally evaluated (not ignored by default), especially frequency caps and suppression controls.
 - No unknown fields are introduced.
 
 When editing existing config, keep diffs minimal and preserve unrelated campaigns.
@@ -179,15 +191,19 @@ Decision gate (mandatory unless user already specified mode):
 When the user chooses bundle mode:
 
 1. Use platform/startup/resource information discovered from existing code and `openclix-init` outputs.
-2. Copy `.openclix/campaigns/openclix-config.json` into the app resource location used by that project:
-   - React Native / Expo: existing `assets/` or project resource pattern.
-   - Flutter: existing asset path and `pubspec.yaml` convention.
-   - iOS: existing app target bundle resource location.
-   - Android: existing `assets/` or `res/raw` pattern.
-3. Keep filename stable unless project convention requires a different name.
-4. Set `OpenClixConfig.endpoint` to the bundled config path identifier used by the project.
-5. Update startup code to load JSON from that same bundled path, parse `Config`, then call `OpenClixCampaignManager.replaceConfig(...)` after initialization.
-6. Run platform build/analysis checks after wiring.
+2. Resolve the runtime bundle target path in this order:
+   - Use the exact existing load path already referenced in code.
+   - If no load path exists yet, use a fallback default:
+     - React Native / Expo: `assets/openclix/openclix-config.json`
+     - Flutter: `assets/openclix/openclix-config.json` (and register it in `pubspec.yaml`)
+     - iOS: `<app-target>/OpenClix/openclix-config.json` (add to Copy Bundle Resources)
+     - Android: `app/src/main/assets/openclix/openclix-config.json`
+3. Copy `.openclix/campaigns/openclix-config.json` to that resolved runtime path.
+4. Keep filename as lowercase `openclix-config.json` unless the project already has a different runtime filename and loader reference.
+5. Set `OpenClixConfig.endpoint` to the same bundled path identifier used by the runtime loader.
+6. Update startup code to load JSON from that exact bundled path, parse `Config`, then call `OpenClixCampaignManager.replaceConfig(...)` after initialization.
+7. Run platform build/analysis checks after wiring.
+8. Perform a parity check: copied file path, loader path reference, and `OpenClixConfig.endpoint` identifier must all match.
 
 ### B) Hosted HTTP Delivery (User-Owned Server)
 
@@ -210,6 +226,7 @@ Completion requirements for implementation tasks:
 
 - selected delivery mode reported
 - source config path and applied runtime config path/URL reported
+- for bundle mode: case-sensitive filename and path parity check result reported
 - `OpenClixConfig.endpoint` value/location updated and reported
 - resource file path reported for bundle mode
 - modified startup/init file paths reported
@@ -225,6 +242,8 @@ Completion requirements for implementation tasks:
 - Use global quiet-hour controls before introducing ad-hoc per-campaign windows.
 - After config generation, inspect existing OpenClix wiring and ask the user to choose bundle vs hosted delivery if not already specified.
 - Reuse project facts discovered by `openclix-init` when selecting resource path and startup patch points.
+- For bundle delivery, never guess a new directory when code already points to a concrete path.
+- Use lowercase `openclix-config.json` unless an existing runtime loader already requires another exact filename.
 - Do not rely on non-HTTP endpoints being auto-loaded by `OpenClix.initialize(...)`.
 - For local JSON delivery, always set `OpenClixConfig.endpoint` to the chosen bundled path and wire explicit resource load + `OpenClixCampaignManager.replaceConfig(...)`.
 - For remote JSON delivery, set `OpenClixConfig.endpoint` to HTTPS URL and keep the payload schema-compatible with `openclix/config/v1`.

--- a/skills/openclix-design-campaigns/references/openclix-campaign-playbook.md
+++ b/skills/openclix-design-campaigns/references/openclix-campaign-playbook.md
@@ -71,6 +71,8 @@ Before adding many campaigns, define:
 
 Avoid duplicating these protections per campaign.
 
+Also evaluate campaign-level `frequency_cap` for high-volume triggers.
+
 ## 6) Keep Copy Personal But Controlled
 
 Message templates support `{{key}}` placeholders resolved from event payloads.
@@ -85,6 +87,11 @@ Hard schema limits:
 
 - title <= 120
 - body <= 500
+
+Also evaluate optional message fields when relevant:
+
+- `image_url` for rich-notification visuals
+- `landing_url` for deep-link routing
 
 ## 7) Recurring Pattern Templates
 
@@ -127,7 +134,19 @@ Hard schema limits:
 }
 ```
 
-## 8) Final Pre-Handoff Checks
+## 8) Feature Coverage Pass (Mandatory For New Campaigns)
+
+Before finalizing config, explicitly evaluate all configurable levers in schema:
+
+- global: `settings.frequency_cap`, `settings.do_not_disturb`
+- campaign: `frequency_cap`
+- event triggers: `delay_seconds`, `cancel_event`
+- recurring triggers: `start_at`, `end_at`, `rule.interval`, `weekly_rule.days_of_week`, `time_of_day`
+- message: `image_url`, `landing_url`, verified `{{key}}` placeholders
+
+Use all relevant levers. If you skip a lever, document why.
+
+## 9) Final Pre-Handoff Checks
 
 Before presenting output:
 
@@ -137,7 +156,7 @@ Before presenting output:
 - verify unknown fields are absent
 - verify every campaign message has both title and body
 
-## 9) Delivery Mode Decision And Runtime Wiring
+## 10) Delivery Mode Decision And Runtime Wiring
 
 When the task includes app implementation, complete these steps after config generation.
 
@@ -156,14 +175,18 @@ Before code changes:
 
 If user chooses bundle mode:
 
-1. Pick resource path from existing project conventions (prefer `openclix-init` findings):
-   - React Native / Expo: existing `assets/` or app-level resource folder
-   - Flutter: existing asset folder pattern and `pubspec.yaml` declaration style
-   - iOS: existing app target bundle resource groups
-   - Android: existing `app/src/main/assets` or `res/raw` usage
-2. Copy generated config JSON into that resource path.
-3. Set `OpenClixConfig.endpoint` to the bundled config path identifier used by the app.
-4. Initialize OpenClix, then read JSON from the same bundled path, parse into `Config`, and call `OpenClixCampaignManager.replaceConfig(parsedConfig)`.
+1. Resolve the runtime path in this order:
+   - existing loader path in code (preferred)
+   - fallback defaults when loader path does not exist yet:
+     - React Native / Expo: `assets/openclix/openclix-config.json`
+     - Flutter: `assets/openclix/openclix-config.json` + `pubspec.yaml` registration
+     - iOS: `<app-target>/OpenClix/openclix-config.json` + Copy Bundle Resources entry
+     - Android: `app/src/main/assets/openclix/openclix-config.json`
+2. Copy generated config JSON to that exact path.
+3. Keep filename lowercase `openclix-config.json` unless existing code already references a different filename.
+4. Set `OpenClixConfig.endpoint` to the same bundled-path identifier used by the app.
+5. Initialize OpenClix, then read JSON from that exact bundled path, parse into `Config`, and call `OpenClixCampaignManager.replaceConfig(parsedConfig)`.
+6. Verify path parity: copied path, loader reference, and endpoint identifier all match.
 
 Reason: `OpenClix.initialize(...)` auto-loads only HTTP(S) endpoints; non-HTTP endpoints require explicit config replacement.
 

--- a/skills/openclix-init/SKILL.md
+++ b/skills/openclix-init/SKILL.md
@@ -20,6 +20,8 @@ Use a local-source integration model (shadcn-style): copy, adapt, wire, verify.
 - Do not add or update dependencies without explicit user approval.
 - Run a build after integration and fix only integration-caused issues.
 - Do not use in-memory fallback in production integration paths.
+- For bundled JSON config delivery, keep runtime loader path and copied file path identical (same directory + same case-sensitive filename).
+- Use `openclix-config.json` as the default filename; do not invent case variants such as `OpenClix-config.json`.
 
 ## Platform Detection
 
@@ -131,6 +133,23 @@ OpenClix files must stay grouped in a dedicated location:
 - iOS: `OpenClix/` or `Sources/OpenClix/`
 - Android: `app/src/main/kotlin/ai/openclix/` with `ai.openclix.*` packages
 
+## Bundled Config Path Contract
+
+When integration includes bundled config delivery (non-HTTP endpoint), enforce this contract:
+
+1. Detect the exact runtime load path from current startup code first.
+2. Copy `openclix-config.json` to that exact path.
+3. If no runtime load path exists yet, use these defaults:
+   - React Native / Expo: `assets/openclix/openclix-config.json`
+   - Flutter: `assets/openclix/openclix-config.json` and add it to `pubspec.yaml`
+   - iOS: `<app-target>/OpenClix/openclix-config.json` and include in "Copy Bundle Resources"
+   - Android: `app/src/main/assets/openclix/openclix-config.json`
+4. Ensure any bundled-path identifier (`OpenClixConfig.endpoint`, asset key, bundle filename) matches the copied file path exactly.
+5. Run a final path parity check before handoff and report:
+   - source config file path
+   - bundled runtime file path
+   - runtime loader reference location(s)
+
 ## Dependency Policy
 
 Before changing dependencies:
@@ -163,5 +182,6 @@ If build fails, apply minimal targeted fixes and retry. Stop only on hard blocke
 - Existing app code changes are minimal and localized.
 - No unapproved dependency additions or upgrades.
 - Adapter wiring prefers existing dependencies and fails fast when unavailable.
+- Bundled config path/filename parity verified when using local resource delivery.
 - Build verification executed.
 - Any remaining blockers clearly reported.


### PR DESCRIPTION
## Summary
- enforce deterministic bundled config placement for `openclix-config.json` in `openclix-init`
- require case-sensitive path/filename parity checks between copied file, loader path, and `OpenClixConfig.endpoint`
- strengthen `openclix-design-campaigns` to resolve bundle path by existing runtime references first, with explicit platform defaults
- add mandatory feature coverage pass for new campaigns to evaluate and use all relevant schema levers (including global + campaign frequency caps)

## Why
`openclix-config.json` could be placed in a directory that did not match runtime loading behavior, causing runtime config read errors. Campaign authoring guidance also did not force full use of available config controls.

## Files Changed
- `skills/openclix-init/SKILL.md`
- `skills/openclix-design-campaigns/SKILL.md`
- `skills/openclix-design-campaigns/references/openclix-campaign-playbook.md`

## Validation
- doc/skill updates only; no runtime code changes
- verified git diff includes only the three intended files
