### PR TITLE
chore(paths): standardize project outputs to .openclix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,6 @@ Thumbs.db
 # Agents
 .agent/
 .claude/
-.clix/
+.openclix/
 .cursor/
 .gemini/

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Paste this prompt into your coding agent:
 Install OpenClix skills from https://github.com/openclix/openclix and integrate OpenClix into this project.
 Use openclix-init to detect platform, copy templates into the dedicated OpenClix namespace,
 wire initialization/event/lifecycle touchpoints, and run build verification.
-Then use openclix-design-campaigns to create .clix/campaigns/app-profile.json
-and generate .clix/campaigns/openclix-config.json.
+Then use openclix-design-campaigns to create .openclix/campaigns/app-profile.json
+and generate .openclix/campaigns/openclix-config.json.
 Do not add dependencies without approval.
 ```
 
@@ -82,7 +82,7 @@ npx skills add openclix/openclix
 ```
 
 2. Run `openclix-init` to integrate templates and touchpoints.
-3. Run `openclix-design-campaigns` to generate `.clix/campaigns/openclix-config.json`.
+3. Run `openclix-design-campaigns` to generate `.openclix/campaigns/openclix-config.json`.
 4. Run `openclix-analytics` to detect provider wiring and generate impact artifacts.
 5. Run `openclix-update-campaigns` to produce conservative recommendation drafts.
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -14,8 +14,8 @@ Use this prompt in your coding agent:
 Install OpenClix skills from https://github.com/openclix/openclix and integrate OpenClix into this project.
 Use openclix-init to detect platform, copy templates into the dedicated OpenClix namespace,
 wire initialization/event/lifecycle touchpoints, and run build verification.
-Then use openclix-design-campaigns to create .clix/campaigns/app-profile.json
-and generate .clix/campaigns/openclix-config.json.
+Then use openclix-design-campaigns to create .openclix/campaigns/app-profile.json
+and generate .openclix/campaigns/openclix-config.json.
 Then use openclix-analytics to detect installed Firebase/PostHog/Mixpanel/Amplitude,
 forward OpenClix events with openclix tags, and produce a pre/post impact report
 for D7 retention and engagement metrics.

--- a/docs/getting-started/verification.mdx
+++ b/docs/getting-started/verification.mdx
@@ -15,13 +15,13 @@ Use this checklist after running the workflow.
 
 ## Artifact checks
 
-- `.clix/campaigns/openclix-config.json` exists and is schema-valid against `https://openclix.ai/schemas/openclix.schema.json`.
-- `.clix/analytics/impact-metrics.json` exists.
-- `.clix/analytics/impact-report.md` exists.
-- `.clix/campaigns/update-recommendations.json` exists after `openclix-update-campaigns`.
-- `.clix/campaigns/openclix-config.next.json` exists after `openclix-update-campaigns`.
-- `.clix/automation/run-summary.json` exists after running retention ops automation.
-- `.clix/automation/prompts/` contains expected agent prompt files.
+- `.openclix/campaigns/openclix-config.json` exists and is schema-valid against `https://openclix.ai/schemas/openclix.schema.json`.
+- `.openclix/analytics/impact-metrics.json` exists.
+- `.openclix/analytics/impact-report.md` exists.
+- `.openclix/campaigns/update-recommendations.json` exists after `openclix-update-campaigns`.
+- `.openclix/campaigns/openclix-config.next.json` exists after `openclix-update-campaigns`.
+- `.openclix/automation/run-summary.json` exists after running retention ops automation.
+- `.openclix/automation/prompts/` contains expected agent prompt files.
 
 ## Schema validation commands
 
@@ -32,19 +32,19 @@ Use the canonical schema URL:
 Run:
 
 ```bash
-jq . .clix/campaigns/openclix-config.json >/dev/null
+jq . .openclix/campaigns/openclix-config.json >/dev/null
 npx --yes ajv-cli validate \
   -s https://openclix.ai/schemas/openclix.schema.json \
-  -d .clix/campaigns/openclix-config.json
+  -d .openclix/campaigns/openclix-config.json
 ```
 
 If remote schema fetch is restricted:
 
 ```bash
-curl -fsSL https://openclix.ai/schemas/openclix.schema.json -o .clix/campaigns/openclix.schema.json
+curl -fsSL https://openclix.ai/schemas/openclix.schema.json -o .openclix/campaigns/openclix.schema.json
 npx --yes ajv-cli validate \
-  -s .clix/campaigns/openclix.schema.json \
-  -d .clix/campaigns/openclix-config.json
+  -s .openclix/campaigns/openclix.schema.json \
+  -d .openclix/campaigns/openclix-config.json
 ```
 
 ## Retention ops automation check
@@ -60,8 +60,8 @@ bash scripts/retention_ops_automation.sh \
 Validate:
 
 - Script exits with code `0`.
-- `.clix/automation/run-summary.json` reports `status: "ok"`.
-- Prompt files are generated under `.clix/automation/prompts/`.
+- `.openclix/automation/run-summary.json` reports `status: "ok"`.
+- Prompt files are generated under `.openclix/automation/prompts/`.
 
 ## Behavior checks
 

--- a/docs/getting-started/workflow.mdx
+++ b/docs/getting-started/workflow.mdx
@@ -23,8 +23,8 @@ description: "Recommended agent-based mobile app retention and engagement automa
 
 Expected output:
 
-- `.clix/campaigns/app-profile.json`
-- `.clix/campaigns/openclix-config.json`
+- `.openclix/campaigns/app-profile.json`
+- `.openclix/campaigns/openclix-config.json`
 
 ## 3. Measure impact with `openclix-analytics`
 
@@ -36,8 +36,8 @@ Expected output:
 
 Expected output:
 
-- `.clix/analytics/impact-metrics.json`
-- `.clix/analytics/impact-report.md`
+- `.openclix/analytics/impact-metrics.json`
+- `.openclix/analytics/impact-report.md`
 
 ## 4. Draft campaign operations with `openclix-update-campaigns`
 
@@ -49,8 +49,8 @@ Expected output:
 
 Expected output:
 
-- `.clix/campaigns/update-recommendations.json`
-- `.clix/campaigns/openclix-config.next.json`
+- `.openclix/campaigns/update-recommendations.json`
+- `.openclix/campaigns/openclix-config.next.json`
 
 ## 5. Run agent retention operations with `retention_ops_automation.sh`
 
@@ -68,10 +68,10 @@ Run from the OpenClix repository root, or use an absolute script path if you are
 
 Expected output:
 
-- `.clix/automation/run-summary.json`
-- `.clix/automation/prompts/openclaw.md`
-- `.clix/automation/prompts/claude-code.md`
-- `.clix/automation/prompts/codex.md`
+- `.openclix/automation/run-summary.json`
+- `.openclix/automation/prompts/openclaw.md`
+- `.openclix/automation/prompts/claude-code.md`
+- `.openclix/automation/prompts/codex.md`
 
 ## 6. Maintain Claude plugin registration
 

--- a/docs/guides/agent-retention-automation.mdx
+++ b/docs/guides/agent-retention-automation.mdx
@@ -57,16 +57,16 @@ CLI options:
 - `--impact-file <path>`
 - `--campaign-metrics-file <path>`
 - `--config-file <path>`
-- `--output-dir <path>` (default: `.clix/automation`)
+- `--output-dir <path>` (default: `.openclix/automation`)
 
 ## Generated artifacts
 
-- `.clix/automation/run-summary.json`
-- `.clix/automation/prompts/openclaw.md`
-- `.clix/automation/prompts/claude-code.md`
-- `.clix/automation/prompts/codex.md`
+- `.openclix/automation/run-summary.json`
+- `.openclix/automation/prompts/openclaw.md`
+- `.openclix/automation/prompts/claude-code.md`
+- `.openclix/automation/prompts/codex.md`
 
-The script also generates evaluator outputs in `.clix/automation/evaluator/` so dry-run usage can stay isolated from active campaign files.
+The script also generates evaluator outputs in `.openclix/automation/evaluator/` so dry-run usage can stay isolated from active campaign files.
 
 ## Weekly / biweekly operating cadence
 

--- a/docs/guides/analytics-impact.mdx
+++ b/docs/guides/analytics-impact.mdx
@@ -24,8 +24,8 @@ If no supported provider exists, the workflow should stop and provide setup guid
 
 ## Output artifacts
 
-- `.clix/analytics/impact-metrics.json`
-- `.clix/analytics/impact-report.md`
+- `.openclix/analytics/impact-metrics.json`
+- `.openclix/analytics/impact-report.md`
 
 Next: [Agent Retention Automation](/guides/agent-retention-automation)
 

--- a/docs/guides/campaign-design.mdx
+++ b/docs/guides/campaign-design.mdx
@@ -22,5 +22,5 @@ Use `openclix-design-campaigns` to convert product goals + event taxonomy into e
 
 ## Output artifacts
 
-- `.clix/campaigns/app-profile.json`
-- `.clix/campaigns/openclix-config.json`
+- `.openclix/campaigns/app-profile.json`
+- `.openclix/campaigns/openclix-config.json`

--- a/scripts/retention_ops_automation.sh
+++ b/scripts/retention_ops_automation.sh
@@ -35,7 +35,7 @@ Options:
   --impact-file <path>              Path to impact-metrics.json
   --campaign-metrics-file <path>    Path to campaign-metrics.json
   --config-file <path>              Path to openclix-config.json
-  --output-dir <path>               Output directory (default: .clix/automation)
+  --output-dir <path>               Output directory (default: .openclix/automation)
   --dry-run                         Keep evaluator outputs inside output directory only
   --help                            Show this help
 
@@ -295,10 +295,10 @@ if [[ ! -d "$ROOT" ]]; then
 fi
 
 ROOT="$(cd "$ROOT" && pwd)"
-IMPACT_FILE="${IMPACT_FILE:-$ROOT/.clix/analytics/impact-metrics.json}"
-CAMPAIGN_METRICS_FILE="${CAMPAIGN_METRICS_FILE:-$ROOT/.clix/analytics/campaign-metrics.json}"
-CONFIG_FILE="${CONFIG_FILE:-$ROOT/.clix/campaigns/openclix-config.json}"
-OUTPUT_DIR="${OUTPUT_DIR:-$ROOT/.clix/automation}"
+IMPACT_FILE="${IMPACT_FILE:-$ROOT/.openclix/analytics/impact-metrics.json}"
+CAMPAIGN_METRICS_FILE="${CAMPAIGN_METRICS_FILE:-$ROOT/.openclix/analytics/campaign-metrics.json}"
+CONFIG_FILE="${CONFIG_FILE:-$ROOT/.openclix/campaigns/openclix-config.json}"
+OUTPUT_DIR="${OUTPUT_DIR:-$ROOT/.openclix/automation}"
 
 IMPACT_FILE="$(resolve_path "$ROOT" "$IMPACT_FILE")"
 CAMPAIGN_METRICS_FILE="$(resolve_path "$ROOT" "$CAMPAIGN_METRICS_FILE")"


### PR DESCRIPTION
## Summary
- Standardized temporary/output paths from .clix/ to .openclix/ across docs, scripts, and gitignore.
- Updated .gitignore to ignore .openclix.
- Aligned retention automation script defaults and docs/examples to .openclix.

## Testing
- Not run (docs/scripts path text updates only).