### PR TITLE
feat(config): version openclix schema contract to 0.1.0

### DIFF
--- a/docs/getting-started/workflow.mdx
+++ b/docs/getting-started/workflow.mdx
@@ -19,7 +19,7 @@ description: "Recommended agent-based mobile app retention and engagement automa
 
 - Creates a structured campaign planning profile
 - Designs lifecycle campaigns (onboarding/habit/re-engagement/milestone/feature discovery)
-- Produces schema-valid config (`openclix/config/v1`)
+- Produces schema-valid config (`0.1.0`)
 
 Expected output:
 

--- a/docs/reference/project-status.mdx
+++ b/docs/reference/project-status.mdx
@@ -7,7 +7,7 @@ description: "Current project status and implementation focus."
 | --- | --- | --- |
 | Core project spec / direction | Defined | Scope, use cases, and architecture direction are documented. |
 | Source-distributed reference runtime | Available (template-based) | `openclix-init` provides React Native / Flutter / iOS / Android source templates with verification scripts. |
-| Config JSON runtime model | Implemented in current templates | `openclix/config/v1` schema and runtime touchpoints for bundled or HTTPS config are available in the workflow. |
+| Config JSON runtime model | Implemented in current templates | `0.1.0` schema and runtime touchpoints for bundled or HTTPS config are available in the workflow. |
 | Agent retention operations workflow | Implemented (review-loop automation) | `openclix-analytics` + `openclix-update-campaigns` + `retention_ops_automation.sh` generate review artifacts with explicit human approval gates. |
 | `openclix-config.json` HTTP delivery | Supported (app-owned endpoint) | Hosted JSON delivery is supported without requiring OpenClix-hosted services. |
 | Hosted control plane | Not required | Local-first path does not require Clix-hosted services. |

--- a/scripts/validate_config.sh
+++ b/scripts/validate_config.sh
@@ -81,8 +81,8 @@ if ! jq -e '."$schema" == "https://openclix.ai/schemas/openclix.schema.json"' "$
 fi
 
 # 3b. schema_version value
-if ! jq -e '.schema_version == "openclix/config/v1"' "${CONFIG_FILE}" >/dev/null 2>&1; then
-  print_fail "schema_version must be exactly \"openclix/config/v1\""
+if ! jq -e '.schema_version == "0.1.0"' "${CONFIG_FILE}" >/dev/null 2>&1; then
+  print_fail "schema_version must be exactly \"0.1.0\""
 fi
 
 # 3c. Ensure .campaigns exists and is an object

--- a/skills/openclix-design-campaigns/SKILL.md
+++ b/skills/openclix-design-campaigns/SKILL.md
@@ -112,7 +112,7 @@ Remote delivery note:
 Guarantee these invariants:
 
 - `"$schema"` is exactly `https://openclix.ai/schemas/openclix.schema.json`.
-- `schema_version` is exactly `openclix/config/v1`.
+- `schema_version` is exactly `0.1.0`.
 - `config_version` is explicit and traceable.
 - Campaign IDs are kebab-case.
 - Campaign `type` is `campaign`.
@@ -143,7 +143,7 @@ Fallback path (outside the repo or when the script is unavailable):
      `npx --yes -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 ajv validate --spec=draft2020 -c ajv-formats -s ./references/schemas/openclix.schema.json -d <config-file>`
    - If you are outside the repo (no local schema), use the published canonical schema URL:
      `npx --yes -p ajv-cli@5.0.0 -p ajv-formats@3.0.1 ajv validate --spec=draft2020 -c ajv-formats -s https://openclix.ai/schemas/openclix.schema.json -d <config-file>`
-3. Manually verify: `$schema` is `https://openclix.ai/schemas/openclix.schema.json`, `schema_version` is `openclix/config/v1`, campaign keys are kebab-case, every campaign has `type: "campaign"`, and each `trigger.type` value has its matching sub-object key.
+3. Manually verify: `$schema` is `https://openclix.ai/schemas/openclix.schema.json`, `schema_version` is `0.1.0`, campaign keys are kebab-case, every campaign has `type: "campaign"`, and each `trigger.type` value has its matching sub-object key.
 
 ### App Profile Validation
 
@@ -246,7 +246,7 @@ Completion requirements for implementation tasks:
 - Use lowercase `openclix-config.json` unless an existing runtime loader already requires another exact filename.
 - Do not rely on non-HTTP endpoints being auto-loaded by `OpenClix.initialize(...)`.
 - For local JSON delivery, always set `OpenClixConfig.endpoint` to the chosen bundled path and wire explicit resource load + `OpenClixCampaignManager.replaceConfig(...)`.
-- For remote JSON delivery, set `OpenClixConfig.endpoint` to HTTPS URL and keep the payload schema-compatible with `openclix/config/v1`.
+- For remote JSON delivery, set `OpenClixConfig.endpoint` to HTTPS URL and keep the payload schema-compatible with `0.1.0`.
 - When asked, provide environment-specific upload guidance rather than generic hosting advice.
 - Keep integration edits minimal and aligned with existing project structure.
 

--- a/skills/openclix-design-campaigns/references/json-schemas.md
+++ b/skills/openclix-design-campaigns/references/json-schemas.md
@@ -106,7 +106,7 @@ Use this shape to capture campaign design context:
 `openclix.schema.json` is the source of truth. Key constraints:
 
 - `"$schema"` must be `https://openclix.ai/schemas/openclix.schema.json`
-- `schema_version` must be `openclix/config/v1`
+- `schema_version` must be `0.1.0`
 - campaign keys must be kebab-case
 - one campaign has one `message`
 - `trigger.type` must be `event`, `scheduled`, or `recurring`
@@ -118,7 +118,7 @@ Minimal valid example:
 ```json
 {
   "$schema": "https://openclix.ai/schemas/openclix.schema.json",
-  "schema_version": "openclix/config/v1",
+  "schema_version": "0.1.0",
   "config_version": "rev-2026-02-26-a",
   "settings": {
     "frequency_cap": {
@@ -181,7 +181,7 @@ Complete config with a one-time scheduled trigger:
 ```json
 {
   "$schema": "https://openclix.ai/schemas/openclix.schema.json",
-  "schema_version": "openclix/config/v1",
+  "schema_version": "0.1.0",
   "config_version": "rev-2026-03-01-a",
   "settings": {
     "frequency_cap": {
@@ -224,7 +224,7 @@ Complete config with a weekly recurring trigger:
 ```json
 {
   "$schema": "https://openclix.ai/schemas/openclix.schema.json",
-  "schema_version": "openclix/config/v1",
+  "schema_version": "0.1.0",
   "config_version": "rev-2026-03-01-b",
   "settings": {
     "frequency_cap": {

--- a/skills/openclix-init/references/openclix.schema.json
+++ b/skills/openclix-init/references/openclix.schema.json
@@ -26,10 +26,10 @@
         },
         "schema_version": {
           "type": "string",
-          "const": "openclix/config/v1",
-          "description": "Schema contract version. The SDK uses this value to select the correct parser.",
+          "const": "0.1.0",
+          "description": "Semantic schema contract version synced with the codebase release. The SDK uses this value to select the correct parser.",
           "examples": [
-            "openclix/config/v1"
+            "0.1.0"
           ]
         },
         "config_version": {

--- a/skills/openclix-init/templates/android/services/ConfigValidator.kt
+++ b/skills/openclix-init/templates/android/services/ConfigValidator.kt
@@ -223,12 +223,12 @@ fun validateConfig(config: Config): ValidationResult {
     val errors = mutableListOf<ValidationIssue>()
     val warnings = mutableListOf<ValidationIssue>()
 
-    if (config.schema_version != "openclix/config/v1") {
+    if (config.schema_version != "0.1.0") {
         errors.add(
             ValidationIssue(
                 path = ".schema_version",
                 code = "INVALID_SCHEMA_VERSION",
-                message = "Expected 'openclix/config/v1', got '${config.schema_version}'"
+                message = "Expected '0.1.0', got '${config.schema_version}'"
             )
         )
     }

--- a/skills/openclix-init/templates/flutter/services/config_validator.dart
+++ b/skills/openclix-init/templates/flutter/services/config_validator.dart
@@ -204,12 +204,12 @@ ValidationResult validateConfig(Config config) {
   final errors = <ValidationIssue>[];
   final warnings = <ValidationIssue>[];
 
-  if (config.schemaVersion != 'openclix/config/v1') {
+  if (config.schemaVersion != '0.1.0') {
     errors.add(
       ValidationIssue(
         path: '.schema_version',
         code: 'INVALID_SCHEMA_VERSION',
-        message: "Expected 'openclix/config/v1', got '${config.schemaVersion}'",
+        message: "Expected '0.1.0', got '${config.schemaVersion}'",
       ),
     );
   }

--- a/skills/openclix-init/templates/ios/Services/ConfigValidator.swift
+++ b/skills/openclix-init/templates/ios/Services/ConfigValidator.swift
@@ -145,12 +145,12 @@ public func validateConfig(_ config: Config) -> ValidationResult {
     var warnings: [ValidationIssue] = []
     // TODO: Validate additionalProperties with raw JSON before Codable decoding.
 
-    if config.schema_version != "openclix/config/v1" {
+    if config.schema_version != "0.1.0" {
         errors.append(
             ValidationIssue(
                 path: ".schema_version",
                 code: "INVALID_SCHEMA_VERSION",
-                message: "Expected 'openclix/config/v1', got '\(config.schema_version)'"
+                message: "Expected '0.1.0', got '\(config.schema_version)'"
             )
         )
     }

--- a/skills/openclix-init/templates/react-native/domain/OpenClixTypes.ts
+++ b/skills/openclix-init/templates/react-native/domain/OpenClixTypes.ts
@@ -10,7 +10,7 @@ export type JsonValue = string | number | boolean | null | JsonValue[] | { [key:
 export interface Config {
   /** Canonical config schema URL (optional but recommended). */
   '$schema'?: 'https://openclix.ai/schemas/openclix.schema.json';
-  schema_version: 'openclix/config/v1';
+  schema_version: '0.1.0';
   config_version: string;
   settings?: Settings;
   /** Map of campaign ID (kebab-case) to campaign definition. */

--- a/skills/openclix-init/templates/react-native/infrastructure/ConfigValidator.ts
+++ b/skills/openclix-init/templates/react-native/infrastructure/ConfigValidator.ts
@@ -280,11 +280,11 @@ export function validateConfig(config: Config): ValidationResult {
     });
   }
 
-  if (config.schema_version !== 'openclix/config/v1') {
+  if (config.schema_version !== '0.1.0') {
     errors.push({
       path: '.schema_version',
       code: 'INVALID_SCHEMA_VERSION',
-      message: `Expected 'openclix/config/v1', got '${config.schema_version}'`,
+      message: `Expected '0.1.0', got '${config.schema_version}'`,
     });
   }
 


### PR DESCRIPTION
## Summary
- switch OpenClix config schema contract from `openclix/config/v1` to semantic version `0.1.0`
- enforce semver-only `schema_version` checks across RN/Android/iOS/Flutter templates
- update validation/docs/skill guidance references to stay consistent with the new contract

## Changes
- update canonical schema const/example in `skills/openclix-init/references/openclix.schema.json`
- update template validators and RN config type literal to require `0.1.0`
- update `scripts/validate_config.sh` spot-check to require `0.1.0`
- update documentation and design-skill references that previously required `openclix/config/v1`

## Verification
- ✅ `./scripts/verify_templates.sh all` (0 failures, warnings: missing `kotlinc` and `flutter` in this environment)
- ⚠️ `./scripts/validate_config.sh /tmp/openclix-valid-0.1.0.json` hit local `npx/ajv-cli` runtime issue (`Cannot find module './common'`)
- ✅\(behavioral\) `./scripts/validate_config.sh /tmp/openclix-invalid-legacy-schema.json` reports `schema_version must be exactly "0.1.0"`
- ✅ `rg -n "openclix/config/v1" .` -> no matches